### PR TITLE
Add support for TLS 1/1.2/1.3 in redirector

### DIFF
--- a/ME3Server_WV/ME3Server.cs
+++ b/ME3Server_WV/ME3Server.cs
@@ -481,7 +481,7 @@ namespace ME3Server_WV
                     TcpClient tcpClient = RedirectorListener.AcceptTcpClient();
                     Logger.Log("[Redirector] New client connected", Color.DarkGreen);
                     SslStream clientStream = new SslStream(tcpClient.GetStream(), true);
-                    clientStream.AuthenticateAsServer(RedirectorCert, false, SslProtocols.Ssl3, false);
+                    clientStream.AuthenticateAsServer(RedirectorCert, false, SslProtocols.Ssl3 | SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, false);
                     Thread tHandler = new Thread(threadRedirectorClientHandler);
                     RedirectorHandlerStruct h = new RedirectorHandlerStruct();
                     h.stream = clientStream;


### PR DESCRIPTION
This fixes the  `IOException: Unable to write data to the transport connection: An existing connection was forcibly closed by the remote host.` error upon starting ME3 (Same issue as described [here](https://me3tweaks.com/forums/viewtopic.php?f=10&t=58)). This is after re-enabling SSL3 in the "Internet Options" dialog, and enabling the required ciphers through PowerShell.

Ran into it on 64-bit Windows 10, build 1803, with .NET 4.7.3 (I think), connecting to a server running on the same machine, listening on a WiFi interface.

Everything works beautifully after changing this line.